### PR TITLE
[FEAT] Track variable owner

### DIFF
--- a/metadata.sql
+++ b/metadata.sql
@@ -68,7 +68,8 @@ CREATE TABLE variables (
     direct boolean,
     formula text,
     answer_number int,
-    personaldata boolean NOT NULL DEFAULT FALSE
+    personaldata boolean NOT NULL DEFAULT FALSE,
+    owner text NOT NULL DEFAULT 'public'
 );
 
 COPY languages (language_id, name) FROM stdin;


### PR DESCRIPTION
Added a new field to the variable table which is a text, should not be null and is 'public' by default.

Ref. CENABLER-3125